### PR TITLE
Fixed Qt5 and Linux builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ Makefile
 
 # User-specific files
 *.suo
-*.user
+*.user*
 *.sln.docstates
 
 # Build results
@@ -22,6 +22,7 @@ Makefile
 x64/
 x86/
 build/
+build-*/
 bld/
 [Bb]in/
 [Oo]bj/
@@ -133,7 +134,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj

--- a/include/ZDLAboutDialog.h
+++ b/include/ZDLAboutDialog.h
@@ -19,8 +19,8 @@
 #ifndef _ZABOUTDIALOG_H_
 #define _ZABOUTDIALOG_H_
 
-#include <QtGui>
 #include <QObject>
+#include <QDialog>
 #include "ZDLWidget.h"
 
 class ZDLAboutDialog: public QDialog{

--- a/include/ZDLImportDialog.h
+++ b/include/ZDLImportDialog.h
@@ -20,7 +20,7 @@
 #ifndef _ZDLIMPORTDIALOG_HPP_
 #define _ZDLIMPORTDIALOG_HPP_
 
-#include <QtGui>
+#include <QDialog>
 
 class ZDLImportDialog : public QDialog {
 	Q_OBJECT

--- a/include/ZDLInterface.h
+++ b/include/ZDLInterface.h
@@ -20,7 +20,7 @@
 #ifndef _ZDLINTERFACE_H_
 #define _ZDLINTERFACE_H_
 
-#include <QtGui>
+#include <QVBoxLayout>
 #include <QObject>
 #include "ZDLWidget.h"
 #include "ZDLMultiPane.h"

--- a/include/ZDLListWidget.h
+++ b/include/ZDLListWidget.h
@@ -20,7 +20,8 @@
 #ifndef _ZLISTWIDGET_H_
 #define _ZLISTWIDGET_H_
 
-#include <QtGui>
+#include <QHBoxLayout>
+#include <QPushButton>
 #include <QObject>
 #include "ZDLWidget.h"
 #include "ZDLListable.h"

--- a/include/ZDLMultiPane.h
+++ b/include/ZDLMultiPane.h
@@ -20,7 +20,9 @@
 #ifndef _MULTIPANE_H_
 #define _MULTIPANE_H_
 
-#include <QtGui>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QPushButton>
 #include <QObject>
 #include "ZDLWidget.h"
 

--- a/include/ZDLNameInput.h
+++ b/include/ZDLNameInput.h
@@ -20,7 +20,8 @@
 #ifndef _ZNAMEINPUT_H_
 #define _ZNAMEINPUT_H_
 
-#include <QtGui>
+#include <QDialog>
+#include <QPushButton>
 #include <QObject>
 #include "ZDLNameListable.h"
 #include "ZDLFileInfo.h"

--- a/include/ZDLQSplitter.h
+++ b/include/ZDLQSplitter.h
@@ -20,7 +20,8 @@
 #ifndef _ZQSPLIT_H_
 #define _ZQSPLIT_H_
 #include <QObject>
-#include <QtGui>
+#include <QSplitter>
+#include <QVBoxLayout>
 #include "ZDLWidget.h"
 
 

--- a/include/ZDLSettingsPane.h
+++ b/include/ZDLSettingsPane.h
@@ -17,7 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QListWidget>
+#include <QComboBox>
+#include <QItemDelegate>
 #include <QObject>
 #include <QStyledItemDelegate>
 #include "ZDLWidget.h"

--- a/include/ZDLSettingsTab.h
+++ b/include/ZDLSettingsTab.h
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QCheckBox>
 #include <QObject>
 #include "ZDLWidget.h"
 #include "ZDLSourcePortList.h"

--- a/include/zdlcommon.h
+++ b/include/zdlcommon.h
@@ -37,6 +37,14 @@
 #define QFD_QT_SEP(x)       x
 #endif
 
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
 extern QDebug *zdlDebug;
 
 #if defined(ZDL_BLACKBOX)

--- a/qzdl.pro
+++ b/qzdl.pro
@@ -22,6 +22,7 @@ UI_DIR = uic
 RCC_DIR = rcc
 
 QT += core gui
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 CONFIG += release
 DEFINES += _ZDL_NO_WARNINGS _ZDL_NO_WFA NOMINMAX QT_HAVE_MMX QT_HAVE_3DNOW QT_HAVE_SSE QT_HAVE_MMXEXT QT_HAVE_SSE2
 
@@ -37,6 +38,10 @@ static {
     *g++|*g++-64|*g++-32 {
         QMAKE_LFLAGS += -static-libstdc++ -static-libgcc -Wl,--as-needed
     }
+}
+
+linux*: {
+    LIBS += -no-pie
 }
 
 INCLUDEPATH += \

--- a/src/ZDLAboutDialog.cpp
+++ b/src/ZDLAboutDialog.cpp
@@ -20,6 +20,8 @@
 #include "ZDLAboutDialog.h"
 #include "ZDLConfigurationManager.h"
 #include <QDialogButtonBox>
+#include <QVBoxLayout>
+#include <QLabel>
 #include "bmp_logo.xpm"
 
 ZDLAboutDialog::ZDLAboutDialog(ZDLWidget *parent):QDialog(parent){

--- a/src/ZDLFileList.cpp
+++ b/src/ZDLFileList.cpp
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QFileDialog>
 #include "ZDLFileList.h"
 #include "ZDLFileListable.h"
 #include "ZDLConfigurationManager.h"

--- a/src/ZDLFilePane.cpp
+++ b/src/ZDLFilePane.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QLabel>
 #include <QApplication>
 #include <QListWidget>
 

--- a/src/ZDLIWadList.cpp
+++ b/src/ZDLIWadList.cpp
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QFileDialog>
 #include "zdlcommon.h"
 #include "ZDLIWadList.h"
 #include "ZDLNameListable.h"

--- a/src/ZDLImportDialog.cpp
+++ b/src/ZDLImportDialog.cpp
@@ -17,6 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QDialogButtonBox>
+#include <QPushButton>
 #include "ZDLImportDialog.h"
 #include "zdlcommon.h"
 

--- a/src/ZDLInterface.cpp
+++ b/src/ZDLInterface.cpp
@@ -17,7 +17,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QtGui>
+#include <QLabel>
+#include <QMessageBox>
+#include <QMenu>
+#include <QAction>
+#include <QFileDialog>
 #include <QApplication>
 #include <QProcessEnvironment>
 #include <QMainWindow>

--- a/src/ZDLListWidget.cpp
+++ b/src/ZDLListWidget.cpp
@@ -17,7 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QtGui>
+#include <QAction>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMessageBox>
 #include <QApplication>
 
 #include "ZDLConfigurationManager.h"

--- a/src/ZDLMainWindow.cpp
+++ b/src/ZDLMainWindow.cpp
@@ -17,7 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QtGui>
+#include <QAction>
+#include <QMessageBox>
 #include <QRegExp>
 #include <QMainWindow>
 
@@ -598,7 +599,7 @@ QStringList ParseParams(const QString& params)
 	switch (wordexp(qPrintable(params), &result, 0)) {
 		case 0:
 			for (size_t i=0; i<result.we_wordc; i++)
-				plist<<result.we_wordv[i];
+				plist<<result.we_wordv[i]; // fall-through
 		case WRDE_NOSPACE:	//If error is WRDE_NOSPACE - there is a possibilty that at least some part of wordexp_t.we_wordv was allocated
 			wordfree (&result);
 	}

--- a/src/ZDLMultiPane.cpp
+++ b/src/ZDLMultiPane.cpp
@@ -18,7 +18,9 @@
  */
  
 
-#include <QtGui>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QFileDialog>
 #include <QApplication>
 #include <QComboBox>
 #include "ZDLConfigurationManager.h"

--- a/src/ZDLNameInput.cpp
+++ b/src/ZDLNameInput.cpp
@@ -17,7 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QLabel>
+#include <QFileDialog>
+#include <QMessageBox>
 #include "ZDLNameInput.h"
 #include "ZDLConfigurationManager.h"
 

--- a/src/ZDLSettingsPane.cpp
+++ b/src/ZDLSettingsPane.cpp
@@ -17,7 +17,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QtGui>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMouseEvent>
 #include <QApplication>
 #include <QComboBox>
 #include "ZDLMapFile.h"

--- a/src/ZDLSettingsTab.cpp
+++ b/src/ZDLSettingsTab.cpp
@@ -17,7 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QLineEdit>
+#include <QLabel>
 #include <QApplication>
 
 #include "ZDLConfigurationManager.h"

--- a/src/ZDLSourcePortList.cpp
+++ b/src/ZDLSourcePortList.cpp
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+
+#include <QFileDialog>
 #include "ZDLSourcePortList.h"
 #include "ZDLNameListable.h"
 #include "ZDLConfigurationManager.h"

--- a/src/qzdl.cpp
+++ b/src/qzdl.cpp
@@ -114,7 +114,9 @@ int main( int argc, char **argv ){
 	QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
 #endif
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 	QApplication::setGraphicsSystem("native");
+#endif
 	QApplication a( argc, argv );
 	qapp = &a;
 	ZDLConfigurationManager::setArgv(eatenArgs);


### PR DESCRIPTION
I tested this at me, it works flawlessly! I use Linux Mint 19.3.

Note: I had to use the `-no-pie` flag that makes executable being working from the file managers (that need for GCC 6 and newer, GCC 5 and older, and CLang has no this mess). If you'll try to build with CLang or an older GCC version the error may appear.
Please verify the build on Qt 4 if you still support it. I had to port the entire project into Qt 5.